### PR TITLE
had to remove decimal places from a calculated array index

### DIFF
--- a/cmd/lepton/static/root.html
+++ b/cmd/lepton/static/root.html
@@ -156,7 +156,7 @@
         for (var i = 0; i < uint16.length; i++) {
           var o = 4*i;
           imgDataSmall.data[o+3] = 255;
-          var intensity = (uint16[i]-minV) * 255/delta;
+          var intensity = Math.round((uint16[i]-minV) * 255/delta);
 
           // Gray.
           //imgDataSmall.data[o] = intensity;


### PR DESCRIPTION
Problem: the browser's camera view was showing mostly black with a few randomly flickering scaled pixels.

I tracked down this problem and did a quick fix by rounding the result for the 'intensity' variable which is used in a calculation for indexing the palette array.  A number with non-zero digits after the decimal being used as an index resulted in 'undefined' from the palette array which was converted to '0', so black was the assigned value of the pixel(s). 

Now the images from the camera show up nicely in the browser.
